### PR TITLE
For JIRA Taks 1205 Frontend should not always request production ES instance

### DIFF
--- a/deploy/charts/kn-es-ingress/templates/ingress.yaml
+++ b/deploy/charts/kn-es-ingress/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.global.exposeNodePorts false }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -39,3 +40,4 @@ spec:
      hosts:
      - {{ .Values.global.externalUrlEs }}
   {{- end }}
+{{- end }}

--- a/deploy/charts/kn-es-ingress/templates/service.yaml
+++ b/deploy/charts/kn-es-ingress/templates/service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.global.exposeNodePorts}} 
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-external-access
+spec:
+  selector:
+    component: elasticsearch
+  ports:
+  - name: http
+    port: 9200
+    targetPort: 9200
+    protocol: TCP
+    nodePort: 30920
+  type: "NodePort"
+{{- end }}

--- a/deploy/charts/kn-ingress/templates/ingress.yaml
+++ b/deploy/charts/kn-ingress/templates/ingress.yaml
@@ -8,7 +8,6 @@ metadata:
     {{- else }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     {{- end }}
-    nginx.ingress.kubernetes.io/enable-cors: "true"
   generation: 2
   name: kn-ingress
 spec:

--- a/deploy/charts/kn-web-server/Chart.yaml
+++ b/deploy/charts/kn-web-server/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: kn-web-server
+version: 0.1.0
+

--- a/deploy/charts/kn-web-server/templates/autoscaler.yaml
+++ b/deploy/charts/kn-web-server/templates/autoscaler.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.autoscaler.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: web
+  minReplicas: {{ .Values.autoscaler.minReplicas }}
+  maxReplicas: {{ .Values.autoscaler.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaler.targetCPUUtilizationPercentage }}
+{{ end }}

--- a/deploy/charts/kn-web-server/templates/configmap.yaml
+++ b/deploy/charts/kn-web-server/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "web-app-config"
+data:
+  # When the config map is mounted as a volume, these will be created as files.
+  web.json: '{
+    {{- if .Values.fallbackUrl -}} "fallbackUrl": {{ .Values.fallbackUrl | quote }}, {{- end -}}
+    {{- if .Values.contentApiBaseUrlInternal -}} "contentApiBaseUrlInternal": {{ .Values.contentApiBaseUrlInternal | quote }}, {{- end -}}
+    "disableAuthenticationFeatures": {{ .Values.disableAuthenticationFeatures }},
+    "baseUrl": {{ .Values.baseUrl | default "/" | quote }}
+  }'

--- a/deploy/charts/kn-web-server/templates/deployment.yaml
+++ b/deploy/charts/kn-web-server/templates/deployment.yaml
@@ -20,9 +20,6 @@ spec:
             "--config", "/etc/config/config.json",
             "--listenPort", "80",
             "--baseExternalUrl", {{ .Values.global.externalUrl | quote }},
-            {{- if .Values.global.externalUrlEs }}
-            "--externalAccessUrlEs", {{ .Values.global.externalAccessUrlEs | quote }},
-            {{- end }}
             "--useLocalStyleSheet", {{ .Values.global.useLocalStyleSheet | default .Values.useLocalStyleSheet | quote }},
             "--registryApiBaseUrlInternal", "http://registry-api/v0",
             {{- range .Values.gapiIds }}

--- a/deploy/charts/kn-web-server/templates/deployment.yaml
+++ b/deploy/charts/kn-web-server/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  strategy:
+    rollingUpdate:
+      maxUnavailable: {{ .Values.global.rollingUpdate.maxUnavailable | default 0 }}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        service: web
+    spec:
+      priorityClassName: magda-8
+      containers:
+      - name: web
+        command: [
+            "node", "/usr/src/app/component/dist/index.js",
+            "--config", "/etc/config/config.json",
+            "--listenPort", "80",
+            "--baseExternalUrl", {{ .Values.global.externalUrl | quote }},
+            {{- if .Values.global.externalUrlEs }}
+            "--externalAccessUrlEs", {{ .Values.global.externalAccessUrlEs | quote }},
+            {{- end }}
+            "--useLocalStyleSheet", {{ .Values.global.useLocalStyleSheet | default .Values.useLocalStyleSheet | quote }},
+            "--registryApiBaseUrlInternal", "http://registry-api/v0",
+            {{- range .Values.gapiIds }}
+            "--gapiIds", {{ . | quote }},
+            {{- end }}
+        ]
+        readinessProbe:
+          httpGet:
+            path: "/"
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+{{- if .Values.global.enableLivenessProbes }}
+        livenessProbe:
+          httpGet:
+            path: "/"
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        - name: NODE_ENV
+          value: production
+        image: {{ template "dockerimage" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        volumeMounts:
+        - mountPath: "/etc/config"
+          name: config
+      volumes:
+      - name: config
+        configMap:
+          name: web-app-config
+          items:
+          - key: web.json
+            path: config.json

--- a/deploy/charts/kn-web-server/templates/service.yaml
+++ b/deploy/charts/kn-web-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+{{- if .Values.global.exposeNodePorts }}
+    nodePort: 30107
+{{- end }}
+  type: {{- if .Values.global.exposeNodePorts}} "NodePort" {{- else }} {{ .Values.service.type | default "ClusterIP" }} {{- end }}
+  selector:
+    service: web

--- a/deploy/charts/kn-web-server/values.yaml
+++ b/deploy/charts/kn-web-server/values.yaml
@@ -1,0 +1,19 @@
+image: {}
+  #repository: data61/
+  #tag: latest
+  #pullPolicy: Always#
+autoscaler:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+resources:
+  requests:
+    cpu: 10m
+    memory: 30Mi
+  limits:
+    cpu: 100m
+disableAuthenticationFeatures: false
+service: {}
+useLocalStyleSheet: false
+contentApiBaseUrlInternal: "http://content-api/v0/"

--- a/deploy/charts/kn/requirements.yaml
+++ b/deploy/charts/kn/requirements.yaml
@@ -27,3 +27,10 @@ dependencies:
     condition: kn-ingress.enabled,global.kn-ingress.enabled
     tags:
       - kn-ingress
+
+  - name: kn-web-server
+    version: 0.1.0
+    repository: file://../kn-web-server
+    condition: kn-web-server.enabled,global.kn-web-server.enabled
+    tags:
+      - kn-web-server

--- a/deploy/charts/kn/values.yaml
+++ b/deploy/charts/kn/values.yaml
@@ -4,6 +4,7 @@ tags:
   admin-api: false
   authorization-api: true
   authorization-db: true
+  cloud-sql-proxy: false
   combined-db: true
   content-api: true
   content-db: true
@@ -20,12 +21,13 @@ tags:
   minion-linked-data-rating: false
   minion-visualization: false
   minion-format: true
-  web-server: true
+  web-server: false
   ingress: false
   connectors: true
   test-chart: true
-  kn-es-ingress: false
+  kn-es-ingress: true
   kn-ingress: false
+  kn-web-server: true
 
 magda:
   gateway:

--- a/deploy/charts/kn/values.yaml
+++ b/deploy/charts/kn/values.yaml
@@ -52,6 +52,8 @@ magda:
       apidocs:
         to: http://apidocs-server/
         redirectTrailingSlash: true
+      es-query/datasets:
+        to: http://elasticsearch:9200/datasets38/_search
       test-chart:
         to: http://test-chart
 

--- a/deploy/minikube.yaml
+++ b/deploy/minikube.yaml
@@ -101,5 +101,13 @@ magda:
         pageSize: 100
         schedule: 30 3 */3 * *
         ignoreHarvestSources: []
+      - image:
+          name: magda-ckan-connector
+        id: dga
+        name: data.gov.au
+        sourceUrl: https://data.gov.au/
+        pageSize: 1000
+        ignoreHarvestSources:
+          - "*"
 
   

--- a/deploy/minikube.yaml
+++ b/deploy/minikube.yaml
@@ -2,7 +2,6 @@ global:
   externalUrlkn: minikube.knowledgenet.co
   externalUrlEs: es.minikube.knowledgenet.co
   externalUrl: http://minikube.knowledgenet.co:30100
-  externalAccessUrlEs: http://es.minikube.knowledgenet.co:39200
   rollingUpdate:
     maxUnavailable: 1
   exposeNodePorts: true

--- a/deploy/minikube.yaml
+++ b/deploy/minikube.yaml
@@ -1,5 +1,8 @@
 global:
+  externalUrlkn: minikube.knowledgenet.co
+  externalUrlEs: es.minikube.knowledgenet.co
   externalUrl: http://minikube.knowledgenet.co:30100
+  externalAccessUrlEs: http://es.minikube.knowledgenet.co:39200
   rollingUpdate:
     maxUnavailable: 1
   exposeNodePorts: true
@@ -39,7 +42,7 @@ tags:
   registry-db: true
   search-api: true
   session-db: true
-  web-server: true
+  web-server: false
   connectors: true
 
   ## Whether to use an ingress, which is necessary for HTTPS and using the Google CDN with
@@ -58,7 +61,17 @@ tags:
 
   ## KN ingress should be disabled by default for local deployment
   kn-ingress: false
-  kn-es-ingress: false
+  kn-es-ingress: true
+
+  ## KN web server
+  kn-web-server: true
+
+kn-web-server:
+  image:
+    repository: "localhost:5000/magda"
+    tag: "latest"
+    pullPolicy: Always
+  useLocalStyleSheet: true
 
 magda:
   gateway:
@@ -77,14 +90,6 @@ magda:
 
   registry-api:
     skipAuthorization: true
-    
-  web-server:
-    image:
-      repository: "localhost:5000/magda"
-      tag: "latest"
-      pullPolicy: Always
-    fallbackUrl: "https://data.gov.au"
-    useLocalStyleSheet: true
 
   connectors:
     includeCronJobs: false

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -71,6 +71,7 @@ kn-web-server:
   image:
     repository: "gcr.io/knowledge-network-192205/staging/magda"
     tag: "0.0.50-RC2"
+    pullPolicy: Always
   useLocalStyleSheet: true
   resources:
     requests:
@@ -85,6 +86,7 @@ magda:
     image:
       repository: "gcr.io/knowledge-network-192205/staging/magda"
       tag: "0.0.50-RC2"
+      pullPolicy: Always
     enableAuthEndpoint: true
     service:
       type: LoadBalancer
@@ -191,7 +193,7 @@ magda:
         memory: 300Mi
 
   connectors:
-    includeCronJobs: true
+    includeCronJobs: false
     config:
       - image:
           name: magda-dap-connector
@@ -201,5 +203,13 @@ magda:
         pageSize: 100
         schedule: 30 3 */3 * *
         ignoreHarvestSources: []
+      - image:
+          name: magda-ckan-connector
+        id: dga
+        name: data.gov.au
+        sourceUrl: https://data.gov.au/
+        pageSize: 1000
+        ignoreHarvestSources:
+          - "*"
 
   

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -2,6 +2,7 @@ global:
   externalUrlkn: staging-test.knowledgenet.co
   externalUrlEs: staging-test-es.knowledgenet.co
   externalUrl: http://staging-test.knowledgenet.co
+  externalAccessUrlEs: http://staging-test-es.knowledgenet.co
   # tlssecret: knco-tls-secret
   rollingUpdate:
     maxUnavailable: 1
@@ -42,7 +43,7 @@ tags:
   registry-db: true
   search-api: true
   session-db: true
-  web-server: true
+  web-server: false
   connectors: true
 
   ## Whether to use an ingress, which is necessary for HTTPS and using the Google CDN with
@@ -62,6 +63,23 @@ tags:
   ## KN ingress should be disabled by default for local deployment
   kn-ingress: true
   kn-es-ingress: true
+
+  ## KN web server
+  kn-web-server: true
+
+
+kn-web-server:
+  image:
+    repository: "gcr.io/knowledge-network-192205/staging/magda"
+    tag: "0.0.50-RC2"
+  useLocalStyleSheet: true
+  resources:
+    requests:
+      cpu: 0
+      memory: 0
+    limits:
+      cpu: 200m
+      memory: 150Mi
 
 magda:
   gateway:
@@ -136,20 +154,6 @@ magda:
     limits:
       cpu: 1000m
       memory: 1000m
-    
-  web-server:
-    image:
-      repository: "gcr.io/knowledge-network-192205/staging/magda"
-      tag: "0.0.50-RC2"
-    fallbackUrl: "https://data.gov.au"
-    useLocalStyleSheet: true
-    resources:
-      requests:
-        cpu: 0
-        memory: 0
-      limits:
-        cpu: 200m
-        memory: 150Mi
 
   authorization-api:
     resources:

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -2,7 +2,6 @@ global:
   externalUrlkn: staging-test.knowledgenet.co
   externalUrlEs: staging-test-es.knowledgenet.co
   externalUrl: http://staging-test.knowledgenet.co
-  externalAccessUrlEs: http://staging-test-es.knowledgenet.co
   # tlssecret: knco-tls-secret
   rollingUpdate:
     maxUnavailable: 1

--- a/magda-kn-web-app/src/api/Api.js
+++ b/magda-kn-web-app/src/api/Api.js
@@ -1,13 +1,18 @@
 const API = {
-    baseUri     : 'http://kn-v2-dev.oznome.csiro.au',
-    datasetCount : '/api/v0/registry/records?limit=0&aspect=dcat-dataset-strings',
-    organisationsCount: '/api/v0/registry/records?limit=0&aspect=organization-details',
-    search       : '/api/v0/search/datasets?query=',
-    dataSetDetail: '/api/v0/registry/records/',
-    dataSetDetail_allAspects: '?aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&dereference=true&optionalAspect=dataset-publisher&optionalAspect=source&optionalAspect=link-status&optionalAspect=dataset-quality-rating&optionalAspect=dataset-linked-data-rating',
-    dataSetOrg: '/api/v0/registry/records?aspect=organization-details&optionalAspect=source&limit=20000',
-    dataSetOrgInfo: '/api/v0/registry/records/',
-    dataSourceCount: '/api/v0/registry/records?limit=0&aspect=organization-details&optionalAspect=source',
-    dataSource: '/api/v0/registry/records?aspect=organization-details&optionalAspect=source&limit=20000'
-}
-export default API
+    baseUri: "http://kn-v2-dev.oznome.csiro.au",
+    datasetCount: "/api/v0/registry/records/count?aspect=dcat-dataset-strings",
+    organisationsCount:
+        "/api/v0/registry/records/count?aspect=organization-details",
+    search: "/api/v0/search/datasets?query=",
+    dataSetDetail: "/api/v0/registry/records/",
+    dataSetDetail_allAspects:
+        "?aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&dereference=true&optionalAspect=dataset-publisher&optionalAspect=source&optionalAspect=link-status&optionalAspect=dataset-quality-rating&optionalAspect=dataset-linked-data-rating",
+    dataSetOrg:
+        "/api/v0/registry/records?aspect=organization-details&optionalAspect=source&limit=20000",
+    dataSetOrgInfo: "/api/v0/registry/records/",
+    dataSourceCount:
+        "/api/v0/registry/records/count?aspect=organization-details&optionalAspect=source",
+    dataSource:
+        "/api/v0/registry/records?aspect=organization-details&optionalAspect=source&limit=20000"
+};
+export default API;

--- a/magda-kn-web-app/src/config.js
+++ b/magda-kn-web-app/src/config.js
@@ -2,7 +2,7 @@
 // const fallbackApiHost = 'http://adb009eba34b.k8s-dev.oznome.csiro.au/'
 // const fallbackApiHost = "http://kn-v2-staging.k8s-dev.oznome.csiro.au/"
 // const fallbackApiHost = "http://staging.knowledgenet.co/"
-const fallbackApiHost = "http://knowledgenet.co/";
+const fallbackApiHost = "http://192.168.99.100:30100/";
 const serverConfig = window.magda_server_config || "";
 const registryApiUrl =
     serverConfig.registryApiBaseUrl || fallbackApiHost + "api/v0/registry/";
@@ -11,10 +11,9 @@ const authApiUrl =
 const API = {
     baseUri: serverConfig || fallbackApiHost,
     authApiUrl: serverConfig.authApiBaseUrl || fallbackApiHost + "api/v0/auth/",
-    datasetCount:
-        registryApiUrl + "records?limit=0&aspect=dcat-dataset-strings",
+    datasetCount: registryApiUrl + "records/count?aspect=dcat-dataset-strings",
     organisationsCount:
-        registryApiUrl + "records?limit=0&aspect=organization-details",
+        registryApiUrl + "records/count?aspect=organization-details",
     search: serverConfig.searchApiBaseUrl || fallbackApiHost + "api/v0/search/",
     dataSetDetail: registryApiUrl + "records/",
     dataSetDetail_allAspects:
@@ -25,7 +24,7 @@ const API = {
     dataSetOrgInfo: registryApiUrl + "records/",
     dataSourceCount:
         registryApiUrl +
-        "records?limit=0&aspect=organization-details&optionalAspect=source",
+        "records/count?aspect=organization-details&optionalAspect=source",
     dataSource:
         registryApiUrl +
         "records?aspect=organization-details&optionalAspect=source&limit=20000",

--- a/magda-kn-web-app/src/config.js
+++ b/magda-kn-web-app/src/config.js
@@ -5,7 +5,7 @@
 const fallbackApiHost = "https://knowledgenet.co/";
 const fallbackEsHost = "https://es.knowledgenet.co/";
 const serverConfig = window.magda_server_config || {};
-const baseUri = serverConfig.baseUri || fallbackApiHost;
+const baseUri = serverConfig.baseUrl || fallbackApiHost;
 const registryApiUrl =
     serverConfig.registryApiBaseUrl || fallbackApiHost + "api/v0/registry/";
 const externalAccessUrlEs = serverConfig.externalAccessUrlEs || fallbackEsHost;

--- a/magda-kn-web-app/src/config.js
+++ b/magda-kn-web-app/src/config.js
@@ -4,13 +4,14 @@
 // const fallbackApiHost = "http://staging.knowledgenet.co/"
 const fallbackApiHost = "https://knowledgenet.co/";
 const fallbackEsHost = "https://es.knowledgenet.co/";
-const serverConfig = window.magda_server_config || "";
+const serverConfig = window.magda_server_config || {};
+const baseUri = serverConfig.baseUri || fallbackApiHost;
 const registryApiUrl =
     serverConfig.registryApiBaseUrl || fallbackApiHost + "api/v0/registry/";
 const externalAccessUrlEs = serverConfig.externalAccessUrlEs || fallbackEsHost;
 
 const API = {
-    baseUri: serverConfig || fallbackApiHost,
+    baseUri,
     authApiUrl: serverConfig.authApiBaseUrl || fallbackApiHost + "api/v0/auth/",
     externalAccessUrlEs,
     datasetCount:
@@ -31,7 +32,7 @@ const API = {
     dataSource:
         registryApiUrl +
         "records?aspect=organization-details&optionalAspect=source&limit=20000",
-    elasticSearch: `${externalAccessUrlEs}datasets38/_search`
+    elasticSearch: `${baseUri}api/v0/es-query/datasets`
 };
 
 export default API;

--- a/magda-kn-web-app/src/config.js
+++ b/magda-kn-web-app/src/config.js
@@ -2,15 +2,17 @@
 // const fallbackApiHost = 'http://adb009eba34b.k8s-dev.oznome.csiro.au/'
 // const fallbackApiHost = "http://kn-v2-staging.k8s-dev.oznome.csiro.au/"
 // const fallbackApiHost = "http://staging.knowledgenet.co/"
-const fallbackApiHost = "http://knowledgenet.co/";
+const fallbackApiHost = "https://knowledgenet.co/";
+const fallbackEsHost = "https://es.knowledgenet.co/";
 const serverConfig = window.magda_server_config || "";
 const registryApiUrl =
     serverConfig.registryApiBaseUrl || fallbackApiHost + "api/v0/registry/";
-const authApiUrl =
-    serverConfig.authApiBaseUrl || fallbackApiHost + "api/v0/auth/";
+const externalAccessUrlEs = serverConfig.externalAccessUrlEs || fallbackEsHost;
+
 const API = {
     baseUri: serverConfig || fallbackApiHost,
     authApiUrl: serverConfig.authApiBaseUrl || fallbackApiHost + "api/v0/auth/",
+    externalAccessUrlEs,
     datasetCount:
         registryApiUrl + "records?limit=0&aspect=dcat-dataset-strings",
     organisationsCount:
@@ -29,7 +31,7 @@ const API = {
     dataSource:
         registryApiUrl +
         "records?aspect=organization-details&optionalAspect=source&limit=20000",
-    elasticSearch: "https://es.knowledgenet.co/datasets32/_search"
+    elasticSearch: `${externalAccessUrlEs}datasets38/_search`
 };
 
 export default API;

--- a/magda-kn-web-app/src/config.js
+++ b/magda-kn-web-app/src/config.js
@@ -2,7 +2,7 @@
 // const fallbackApiHost = 'http://adb009eba34b.k8s-dev.oznome.csiro.au/'
 // const fallbackApiHost = "http://kn-v2-staging.k8s-dev.oznome.csiro.au/"
 // const fallbackApiHost = "http://staging.knowledgenet.co/"
-const fallbackApiHost = "https://knowledgnet.co/";
+const fallbackApiHost = "https://knowledgenet.co/";
 const serverConfig = window.magda_server_config || "";
 const registryApiUrl =
     serverConfig.registryApiBaseUrl || fallbackApiHost + "api/v0/registry/";
@@ -24,7 +24,7 @@ const API = {
     dataSetOrgInfo: registryApiUrl + "records/",
     dataSourceCount:
         registryApiUrl +
-        "records/count?aspect=organization-details&optionalAspect=source",
+        "records?aspect=organization-details&optionalAspect=source&limit=20000",
     dataSource:
         registryApiUrl +
         "records?aspect=organization-details&optionalAspect=source&limit=20000",

--- a/magda-kn-web-app/src/config.js
+++ b/magda-kn-web-app/src/config.js
@@ -2,7 +2,7 @@
 // const fallbackApiHost = 'http://adb009eba34b.k8s-dev.oznome.csiro.au/'
 // const fallbackApiHost = "http://kn-v2-staging.k8s-dev.oznome.csiro.au/"
 // const fallbackApiHost = "http://staging.knowledgenet.co/"
-const fallbackApiHost = "http://192.168.99.100:30100/";
+const fallbackApiHost = "https://knowledgnet.co/";
 const serverConfig = window.magda_server_config || "";
 const registryApiUrl =
     serverConfig.registryApiBaseUrl || fallbackApiHost + "api/v0/registry/";

--- a/magda-kn-web-app/src/dataset/AboutPublisher.js
+++ b/magda-kn-web-app/src/dataset/AboutPublisher.js
@@ -61,7 +61,7 @@ export default class AboutPublisher extends Component {
             }
         };
         fetch(API.elasticSearch, {
-            headers: { contentType: "application/json" },
+            headers: { "Content-Type": "application/json" },
             method: "POST",
             body: JSON.stringify(query)
         })

--- a/magda-kn-web-app/src/dataset/AboutPublisher.js
+++ b/magda-kn-web-app/src/dataset/AboutPublisher.js
@@ -61,10 +61,9 @@ export default class AboutPublisher extends Component {
             }
         };
         fetch(API.elasticSearch, {
-            contentType: "application/json",
+            headers: { contentType: "application/json" },
             method: "POST",
-            body: JSON.stringify(query),
-            dataType: "json"
+            body: JSON.stringify(query)
         })
             .then(res => res.json())
             .then(json => {

--- a/magda-kn-web-app/src/dataset/AboutPublisher.js
+++ b/magda-kn-web-app/src/dataset/AboutPublisher.js
@@ -54,7 +54,7 @@ export default class AboutPublisher extends Component {
             aggs: {
                 keywords_agg: {
                     terms: {
-                        field: "keywords.raw",
+                        field: "keywords.keyword",
                         size: 50
                     }
                 }

--- a/magda-kn-web-app/src/dataset/DataSetListForOrg.js
+++ b/magda-kn-web-app/src/dataset/DataSetListForOrg.js
@@ -124,7 +124,7 @@ export default class DataSetListForOrg extends Component {
             }
         };
         fetch(API.elasticSearch, {
-            headers: { contentType: "application/json" },
+            headers: { "Content-Type": "application/json" },
             method: "POST",
             body: JSON.stringify(query)
         })

--- a/magda-kn-web-app/src/dataset/DataSetListForOrg.js
+++ b/magda-kn-web-app/src/dataset/DataSetListForOrg.js
@@ -117,7 +117,7 @@ export default class DataSetListForOrg extends Component {
             aggs: {
                 keywords_agg: {
                     terms: {
-                        field: "keywords.raw",
+                        field: "keywords.keyword",
                         size: 50
                     }
                 }

--- a/magda-kn-web-app/src/dataset/DataSetListForOrg.js
+++ b/magda-kn-web-app/src/dataset/DataSetListForOrg.js
@@ -124,10 +124,9 @@ export default class DataSetListForOrg extends Component {
             }
         };
         fetch(API.elasticSearch, {
-            contentType: "application/json",
+            headers: { contentType: "application/json" },
             method: "POST",
-            body: JSON.stringify(query),
-            dataType: "json"
+            body: JSON.stringify(query)
         })
             .then(res => res.json())
             .then(json => {

--- a/magda-kn-web-app/src/dataset/PublisherViews.js
+++ b/magda-kn-web-app/src/dataset/PublisherViews.js
@@ -117,10 +117,9 @@ export default class PublisherViews extends Component {
             };
         }
         fetch(API.elasticSearch, {
-            contentType: "application/json",
+            headers: { contentType: "application/json" },
             method: "POST",
-            body: JSON.stringify(query),
-            dataType: "json"
+            body: JSON.stringify(query)
         })
             .then(res => res.json())
             .then(json => {

--- a/magda-kn-web-app/src/dataset/PublisherViews.js
+++ b/magda-kn-web-app/src/dataset/PublisherViews.js
@@ -117,7 +117,7 @@ export default class PublisherViews extends Component {
             };
         }
         fetch(API.elasticSearch, {
-            headers: { contentType: "application/json" },
+            headers: { "Content-Type": "application/json" },
             method: "POST",
             body: JSON.stringify(query)
         })

--- a/magda-kn-web-app/src/dataset/PublisherViews.js
+++ b/magda-kn-web-app/src/dataset/PublisherViews.js
@@ -92,7 +92,7 @@ export default class PublisherViews extends Component {
                 aggs: {
                     formats: {
                         terms: {
-                            field: "keywords.raw",
+                            field: "keywords.keyword",
                             size: 50
                         }
                     }
@@ -109,7 +109,7 @@ export default class PublisherViews extends Component {
                 aggs: {
                     formats: {
                         terms: {
-                            field: "keywords.raw",
+                            field: "keywords.keyword",
                             size: 50
                         }
                     }

--- a/magda-kn-web-app/src/index/GraphStats.js
+++ b/magda-kn-web-app/src/index/GraphStats.js
@@ -11,8 +11,7 @@ export default class GraphStats extends Component {
             dataSet: 0,
             organisations: 0,
             thematicAreas: 0,
-            //datasource: new Map()
-            datasources: 0
+            datasource: new Map()
         };
     }
 
@@ -61,8 +60,7 @@ export default class GraphStats extends Component {
                 } else console.log("Get data error ");
             })
             .then(json => {
-                //this.organizeDataSource(json);
-                this.setState({ datasources: json.count });
+                this.organizeDataSource(json);
             })
             .catch(error => {
                 console.log("error on .catch", error);
@@ -100,7 +98,7 @@ export default class GraphStats extends Component {
                     <Well>
                         <span className="graph-stats-number">
                             <Link to="/datasource">
-                                {this.state.datasources}
+                                {this.state.datasource.size}
                             </Link>
                         </span>
                         <br />

--- a/magda-kn-web-app/src/index/GraphStats.js
+++ b/magda-kn-web-app/src/index/GraphStats.js
@@ -11,7 +11,8 @@ export default class GraphStats extends Component {
             dataSet: 0,
             organisations: 0,
             thematicAreas: 0,
-            datasource: new Map()
+            //datasource: new Map()
+            datasources: 0
         };
     }
 
@@ -32,7 +33,7 @@ export default class GraphStats extends Component {
                 } else console.log("Get data error ");
             })
             .then(json => {
-                this.setState({ dataSet: json.totalCount });
+                this.setState({ dataSet: json.count });
             })
             .catch(error => {
                 console.log("error on .catch", error);
@@ -45,14 +46,14 @@ export default class GraphStats extends Component {
                 } else console.log("Get data error ");
             })
             .then(json => {
-                this.setState({ organisations: json.totalCount });
+                this.setState({ organisations: json.count });
             })
             .catch(error => {
                 console.log("error on .catch", error);
             });
     }
     getDataSource() {
-        fetch(API.dataSource)
+        fetch(API.dataSourceCount)
             .then(response => {
                 // console.log(response)
                 if (response.status === 200) {
@@ -60,7 +61,8 @@ export default class GraphStats extends Component {
                 } else console.log("Get data error ");
             })
             .then(json => {
-                this.organizeDataSource(json);
+                //this.organizeDataSource(json);
+                this.setState({ datasources: json.count });
             })
             .catch(error => {
                 console.log("error on .catch", error);
@@ -68,7 +70,8 @@ export default class GraphStats extends Component {
     }
 
     organizeDataSource(data) {
-        //Source map id as key, souce object as value
+        //Source map id as key, source object as value
+
         let sourceMap = new Map();
         data.records.map(record => {
             if (!sourceMap.has(record.aspects.source.name))
@@ -97,7 +100,7 @@ export default class GraphStats extends Component {
                     <Well>
                         <span className="graph-stats-number">
                             <Link to="/datasource">
-                                {this.state.datasource.size}
+                                {this.state.datasources}
                             </Link>
                         </span>
                         <br />

--- a/magda-kn-web-app/src/search/SearchNavPills.js
+++ b/magda-kn-web-app/src/search/SearchNavPills.js
@@ -139,7 +139,7 @@ export default class SearchNavPills extends Component {
             aggs: {
                 formats: {
                     terms: {
-                        field: "keywords.raw",
+                        field: "keywords.keyword",
                         size: 100
                     }
                 }

--- a/magda-kn-web-app/src/search/SearchNavPills.js
+++ b/magda-kn-web-app/src/search/SearchNavPills.js
@@ -149,7 +149,7 @@ export default class SearchNavPills extends Component {
             ? API.elasticSearch + "?q=" + this.state.searchText
             : API.elasticSearch;
         fetch(queryUrl, {
-            headers: { contentType: "application/json" },
+            headers: { "Content-Type": "application/json" },
             method: "POST",
             body: JSON.stringify(query)
         })

--- a/magda-kn-web-app/src/search/SearchNavPills.js
+++ b/magda-kn-web-app/src/search/SearchNavPills.js
@@ -149,10 +149,9 @@ export default class SearchNavPills extends Component {
             ? API.elasticSearch + "?q=" + this.state.searchText
             : API.elasticSearch;
         fetch(queryUrl, {
-            contentType: "application/json",
+            headers: { contentType: "application/json" },
             method: "POST",
-            body: JSON.stringify(query),
-            dataType: "json"
+            body: JSON.stringify(query)
         })
             .then(res => res.json())
             .then(json => {

--- a/magda-web-server/package.json
+++ b/magda-web-server/package.json
@@ -57,7 +57,7 @@
   },
   "config": {
     "docker": {
-      "name": "magda/magda-web-server",
+      "name": "magda/magda-kn-web-server",
       "include": "node_modules dist Dockerfile package.json"
     }
   },

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -35,6 +35,11 @@ const argv = yargs
         type: "string",
         required: true
     })
+    .option("externalAccessUrlEs", {
+        describe:
+            "The absolute base URL of the KN Elasticsearch, when accessed externally. Used for building sitemap URLs which must be absolute.",
+        type: "string"
+    })
     .option("registryApiBaseUrlInternal", {
         describe: "The url of the registry api for use within the cluster",
         type: "string",
@@ -120,6 +125,9 @@ const apiBaseUrl = addTrailingSlash(
 const webServerConfig = {
     disableAuthenticationFeatures: argv.disableAuthenticationFeatures,
     baseUrl: addTrailingSlash(argv.baseUrl),
+    externalAccessUrlEs: argv.externalAccessUrlEs
+        ? addTrailingSlash(argv.externalAccessUrlEs)
+        : "",
     apiBaseUrl: apiBaseUrl,
     contentApiBaseUrl: addTrailingSlash(
         argv.contentApiBaseUrl ||

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -35,11 +35,6 @@ const argv = yargs
         type: "string",
         required: true
     })
-    .option("externalAccessUrlEs", {
-        describe:
-            "The absolute base URL of the KN Elasticsearch, when accessed externally. Used for building sitemap URLs which must be absolute.",
-        type: "string"
-    })
     .option("registryApiBaseUrlInternal", {
         describe: "The url of the registry api for use within the cluster",
         type: "string",
@@ -125,9 +120,6 @@ const apiBaseUrl = addTrailingSlash(
 const webServerConfig = {
     disableAuthenticationFeatures: argv.disableAuthenticationFeatures,
     baseUrl: addTrailingSlash(argv.baseUrl),
-    externalAccessUrlEs: argv.externalAccessUrlEs
-        ? addTrailingSlash(argv.externalAccessUrlEs)
-        : "",
     apiBaseUrl: apiBaseUrl,
     contentApiBaseUrl: addTrailingSlash(
         argv.contentApiBaseUrl ||


### PR DESCRIPTION
This PR is for JIRA Taks 1205: Frontend should not always request production ES instance

https://jira.csiro.au/secure/RapidBoard.jspa?rapidView=1282&projectKey=OFW&view=planning&selectedIssue=OFW-1205

### Current situation:
The elasticsearch endpoint access URL is now hardcoded in [magda-kn-web-app/src/config.js](https://github.com/CSIRO-enviro-informatics/magda-config-kn/blob/master/magda-kn-web-app/src/config.js)

### Change Summary:

- use `Gateway` route `/api/v0/es-query/datasets` to `http://elasticsearch:9200/datasets38/_search`
- update `elasticSearch` config in  `kn-web-app/config.js` to `${baseUri}api/v0/es-query/datasets`. 
  - This will work both for GKE & local minikube cluster
- Add a `kn-web-server` chart. Was for supplying extra parameters to frontend. Not needed anymore as we proxy elasticsearch `datasets/_search` through `gateway` for frontend now. Still leave here for ease of adding new parameters to frontend codes.
  - Change docker image pulling url for web-server to `[repo]/magda/magda-kn-web-server:[version]`
- Instead of aggregated on field `keywords.raw`, use `keywords.keyword`
- Change `staging` config image pulling policy to `always`. Therefore, it's easier to test.
- Fetch API should passing `content-type` headers via `headers` field
- Turn off cors header on nigix ingress as gateway will add cors headers as well 

** Merged PR: https://github.com/CSIRO-enviro-informatics/magda-config-kn/pull/3 (upgrading counts to use latest magda api)**

### Test

Have deployed to staging-test:

https://staging-test.knowledgenet.co