### PR TITLE
Fixed Failed Web Deployment 

### DIFF
--- a/deploy/charts/kn-web-server/templates/deployment.yaml
+++ b/deploy/charts/kn-web-server/templates/deployment.yaml
@@ -12,7 +12,6 @@ spec:
       labels:
         service: web
     spec:
-      priorityClassName: magda-8
       containers:
       - name: web
         command: [


### PR DESCRIPTION
The current `web` deployment includes a `priorityClassName` field which requires pre-setup on cluster before reference on deployment.

The lower version cluster will ignore this and will successfully create the deployment for `web`.

The newer version cluster (that supports `priorityClass`) will report `cannot find priorityClass magda-8` and failed to create deployment.

Consequently, `Horizontal Pod Autoscaler` will report can't find deployment web.

I've removed the `priorityClassName` field to fix this issue.

@jevy-wangfei :
Please have another try on this branch and let me know if it's working. Thank you~
Please don't forget run `helm dep up deploy/charts/kn` before deployment.
