### PR TITLE
Fixed sign on status 

### DIFF
--- a/magda-kn-web-app/src/NavBar.js
+++ b/magda-kn-web-app/src/NavBar.js
@@ -23,13 +23,24 @@ export default class NavBar extends Component {
             .then(res => {
                 if (res.status === 200) {
                     return res.json();
-                } else if (res.status === 401) {
-                    console.log("User is unauthorized");
-                    return "";
+                } else {
+                    throw new Error(
+                        `Failed to request whoami API, status code: ${
+                            res.status
+                        }`
+                    );
                 }
             })
             .then(json => {
-                if (json) this.setState({ user: json });
+                if (json) {
+                    if (json.isError) {
+                        console.log("User is unauthorized");
+                        console.log(json);
+                        return;
+                    } else {
+                        this.setState({ user: json });
+                    }
+                }
             })
             .catch(error => console.log(error));
     }

--- a/magda-kn-web-app/src/config.js
+++ b/magda-kn-web-app/src/config.js
@@ -2,7 +2,7 @@
 // const fallbackApiHost = 'http://adb009eba34b.k8s-dev.oznome.csiro.au/'
 // const fallbackApiHost = "http://kn-v2-staging.k8s-dev.oznome.csiro.au/"
 // const fallbackApiHost = "http://staging.knowledgenet.co/"
-const fallbackApiHost = "https://knowledgenet.co/";
+const fallbackApiHost = "https://staging-test.knowledgenet.co/";
 const serverConfig = window.magda_server_config || {};
 const baseUri = serverConfig.baseUrl || fallbackApiHost;
 const registryApiUrl =

--- a/magda-kn-web-app/src/user/Profile.js
+++ b/magda-kn-web-app/src/user/Profile.js
@@ -1,78 +1,100 @@
-import React, {Component} from 'react'
-import { Row, Col, Table,  Image } from 'react-bootstrap'
-import API from '../config'
-import './User.css'
+import React, { Component } from "react";
+import { Row, Col, Table, Image } from "react-bootstrap";
+import API from "../config";
+import "./User.css";
 
 export default class Profile extends Component {
-  constructor(props){
-    super(props)
-    this.state = {user: ''}
-  }
+    constructor(props) {
+        super(props);
+        this.state = { user: "" };
+    }
 
-  componentDidMount(){
-    fetch(API.authApiUrl+"users/whoami", {credentials: "include"}).then(res =>{
-      if (res.status === 200){
-        return res.json()
-      }
-    }).then(json =>{
-        console.log(json)
-        if(json){
-            this.setState({user:json})
-        }
-      
-    }).catch(error => console.log(error))
-  }
+    componentDidMount() {
+        fetch(API.authApiUrl + "users/whoami", { credentials: "include" })
+            .then(res => {
+                if (res.status === 200) {
+                    return res.json();
+                } else {
+                    throw new Error(
+                        `Failed to request whoami API, status code: ${
+                            res.status
+                        }`
+                    );
+                }
+            })
+            .then(json => {
+                if (json) {
+                    if (json.isError) {
+                        console.log("User is unauthorized");
+                        console.log(json);
+                        return;
+                    } else {
+                        this.setState({ user: json });
+                    }
+                }
+            })
+            .catch(error => console.log(error));
+    }
 
-  render() {
-    console.log(this.state.user)
-    if(this.state.user === '')  return (<p></p>)
-    if(this.state.user === undefined) return (<p></p>)
-    
-    return(
-    <div className='padding-top'>
-    <Row>
-        <h2>USER PROFILE </h2>
-        <Col xs={6}>
-        <div className="profile">
-        {
-            this.state.user.photoURL === 'none-photoURL'? 
-            <Image src='/img/default-user.png' circle /> 
-            : <Image src={this.state.user.photoURL} circle />
-        } 
-        </div>
-        <div className="detail">
-        <Table striped condensed hover>
-            <tbody>
-                <tr>
-                    <td>User Name:</td>
-                    <td>{this.state.user.displayName}</td>
-                </tr>
+    render() {
+        console.log(this.state.user);
+        if (this.state.user === "") return <p />;
+        if (this.state.user === undefined) return <p />;
 
-                <tr>
-                    <td>Email:</td>
-                    <td>{this.state.user.email}</td>
-                </tr>
-                <tr>
-                    <td>Auth Source:</td>
-                    <td>{this.state.user.source}</td>
-                </tr>
-            </tbody>
-        </Table>
-         </div>
-        </Col>
-        <Col xs={6}>
-            <h4><span className="glyphicon glyphicon-link"></span> My Bookmark</h4> 
-            <h4><span className="glyphicon glyphicon-link"></span> My Favorite </h4> 
-            <h4><span className="glyphicon glyphicon-link"></span> My Searched </h4> 
-        </Col>
+        return (
+            <div className="padding-top">
+                <Row>
+                    <h2>USER PROFILE </h2>
+                    <Col xs={6}>
+                        <div className="profile">
+                            {this.state.user.photoURL === "none-photoURL" ? (
+                                <Image src="/img/default-user.png" circle />
+                            ) : (
+                                <Image src={this.state.user.photoURL} circle />
+                            )}
+                        </div>
+                        <div className="detail">
+                            <Table striped condensed hover>
+                                <tbody>
+                                    <tr>
+                                        <td>User Name:</td>
+                                        <td>{this.state.user.displayName}</td>
+                                    </tr>
 
-    </Row>
-    <Row>
-         <h4><span className="glyphicon glyphicon-link"></span> API TOKENS </h4>   
-        <button className="btn btn-primary"> Generate </button>    
-        </Row>
-    </div>
-    )
-  }
-
+                                    <tr>
+                                        <td>Email:</td>
+                                        <td>{this.state.user.email}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Auth Source:</td>
+                                        <td>{this.state.user.source}</td>
+                                    </tr>
+                                </tbody>
+                            </Table>
+                        </div>
+                    </Col>
+                    <Col xs={6}>
+                        <h4>
+                            <span className="glyphicon glyphicon-link" /> My
+                            Bookmark
+                        </h4>
+                        <h4>
+                            <span className="glyphicon glyphicon-link" /> My
+                            Favorite{" "}
+                        </h4>
+                        <h4>
+                            <span className="glyphicon glyphicon-link" /> My
+                            Searched{" "}
+                        </h4>
+                    </Col>
+                </Row>
+                <Row>
+                    <h4>
+                        <span className="glyphicon glyphicon-link" /> API TOKENS{" "}
+                    </h4>
+                    <button className="btn btn-primary"> Generate </button>
+                </Row>
+            </div>
+        );
+    }
 }


### PR DESCRIPTION
### Summary

Newer version Magda `whoami` API won't response 401 status code when user is not logged in anymore. Instead, it will return `200` with response body similar to the followings:
```
{"isError":true,"errorCode":401,"errorMessage":"Not authorized"}
```
Logged in response still same as before:
```
{
  "id": "27f87c7c-5e71-48bb-b2b2-c669e5136538",
  "displayName": "Jacky Jiang",
  "email": "t83714@gmail.com",
  "photoURL": "//www.gravatar.com/avatar/bed026a33c154abec6852b4e313bf1ce",
  "source": "ckan",
  "isAdmin": true
}
``` 
This PR altered the way of handling `whoami` api response in order to show login status correctly.

### Test

- Checkout this branch
- Go to `magda-kn-web-app`
- run `yarn dev`

The login status should show not logged in now.
 