### PR TITLE
Added Helm chart for manually creating connector jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,3 +473,19 @@ http://staging-test.knowledgenet.co
 
 KN demo test chart URL:
 http://staging-test.knowledgenet.co/api/v0/test-chart/test-api
+
+# Create adhoc Connector Job in cluster
+
+You can create adhoc connector job with the following:
+
+## 1. Edit deploy/charts/connector-job/values.yaml
+
+You can edit `deploy/charts/connector-job/values.yaml` to add / delete connectors to be created.
+
+## 2. Run the following command:
+
+```bash
+helm upgrade connector-job deploy/charts/connector-job --install --namespace kn
+```
+
+This command won't re-create a new job if a job with same name exist. Therefore, you may want to delete the previously complete jobs in order to re-run the connector.

--- a/deploy/charts/connector-job/.helmignore
+++ b/deploy/charts/connector-job/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/connector-job/Chart.yaml
+++ b/deploy/charts/connector-job/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: connector-job
+version: 0.1.0

--- a/deploy/charts/connector-job/templates/_helpers.tpl
+++ b/deploy/charts/connector-job/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "connector-job.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "connector-job.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "connector-job.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "magda.connectorJobSpec" }}
+spec:
+  template:
+    metadata:
+      name: connector-{{ .jobConfig.name }}
+    spec:
+      containers:
+        - name: connector-{{ .jobConfig.id }}
+          image: "{{ .jobConfig.image.repository | default .root.Values.image.repository | default .root.Values.global.image.repository }}/{{ .jobConfig.image.name }}:{{ .jobConfig.image.tag | default .root.Values.image.tag | default .root.Values.global.image.tag }}"
+          imagePullPolicy: {{ .jobConfig.image.pullPolicy | default .root.Values.image.pullPolicy | default .root.Values.global.image.pullPolicy }}
+          command:
+            - "node"
+            - "/usr/src/app/component/dist/index.js"
+            - "--config"
+            - "/etc/config/connector.json"
+            - "--registryUrl"
+            - "http://registry-api/v0"
+          resources:
+{{ .jobConfig.resources | default .root.Values.resources | toYaml | indent 12 }}
+          volumeMounts:
+            - mountPath: /etc/config
+              name: config
+          env: 
+            - name: USER_ID
+              value: 00000000-0000-4000-8000-000000000000
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: jwt-secret
+      restartPolicy: "OnFailure"
+      volumes:
+        - name: config
+          configMap:
+            name: "adhoc-connector-job-config"
+            items:
+              - key: "{{ .jobConfig.id }}.json"
+                path: "connector.json"
+{{- end }}

--- a/deploy/charts/connector-job/templates/configmap.yaml
+++ b/deploy/charts/connector-job/templates/configmap.yaml
@@ -1,0 +1,10 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "adhoc-connector-job-config"
+data:
+  # When the config map is mounted as a volume, these will be created as files.
+{{- range .Values.config }}
+  {{ .id }}.json: '{{ toJson . }}'
+{{- end }}

--- a/deploy/charts/connector-job/templates/job.yaml
+++ b/deploy/charts/connector-job/templates/job.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.includeInitialJobs }}
+{{- range .Values.config }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: connector-{{ .id }}
+{{ $params := dict "root" $ "jobConfig" . }}
+{{ template "magda.connectorJobSpec" $params }}
+...
+{{- end }}
+{{- end }}

--- a/deploy/charts/connector-job/values.yaml
+++ b/deploy/charts/connector-job/values.yaml
@@ -1,0 +1,32 @@
+global:
+  image: {}
+image: 
+  tag: 0.0.50-RC2
+  repository: "data61"
+  pullPolicy: IfNotPresent
+resources:
+  requests:
+    cpu: 50m
+    memory: 30Mi
+  limits:
+    cpu: 100m
+includeInitialJobs: true
+includeCronJobs: false
+config: 
+  - image:
+      name: magda-ckan-connector
+    id: dga
+    name: data.gov.au
+    sourceUrl: https://data.gov.au/
+    pageSize: 1000
+    ignoreHarvestSources:
+      - "*"
+  # You can keep adding more if you not only want to create one adhoc job at once
+  # - image:
+  #     name: magda-dap-connector
+  #   id: dap
+  #   name: CSIRO
+  #   sourceUrl: https://data.csiro.au/dap/ws/v2/
+  #   pageSize: 100
+  #   schedule: 30 3 */3 * *
+  #   ignoreHarvestSources: []


### PR DESCRIPTION
You can create adhoc connector jobs by:

```bash
helm upgrade connector-job deploy/charts/connector-job --install --namespace kn
```

More details see README.md